### PR TITLE
Feature: initializing new route for landing page

### DIFF
--- a/frontend/src/app/[lang]/page.tsx
+++ b/frontend/src/app/[lang]/page.tsx
@@ -1,18 +1,11 @@
-import { getDictionaryServerOnly } from "@/src/dictionaries/default-dictionary-server-only";
+import { redirect } from 'next/navigation'
 import { Locale } from "@/src/config/i18n.config";
 
-export default async function Home({
+export default async function Page({
   params,
 }: {
   params: Promise<{ lang: Locale }>;
 }) {
   const { lang } = await params; // unwrap the promise
-  const dict = await getDictionaryServerOnly(lang);
-
-  return (
-    <main>
-      <h1>{dict.site.name}</h1>
-      <p>{dict.site.description}</p>
-    </main>
-  );
+  redirect(`/${lang}/welcome`)
 }

--- a/frontend/src/app/[lang]/welcome/page.tsx
+++ b/frontend/src/app/[lang]/welcome/page.tsx
@@ -1,0 +1,18 @@
+import { getDictionaryServerOnly } from "@/src/dictionaries/default-dictionary-server-only";
+import { Locale } from "@/src/config/i18n.config";
+
+export default async function welcome({
+  params,
+}: {
+  params: Promise<{ lang: Locale }>;
+}) {
+  const { lang } = await params; // unwrap the promise
+  const dict = await getDictionaryServerOnly(lang);
+
+  return (
+    <main>
+      <h1>{dict.site.name}</h1>
+      <p>{dict.site.description}</p>
+    </main>
+  );
+}


### PR DESCRIPTION
Define uma nova rota para o que será a landing page.

A rota leva a tradução mas o a palavra welcome:``/${lang}/welcome``

O arquivo pages é apenas um redirect para landing como pode ver na imagem:
<img width="446" height="149" alt="image" src="https://github.com/user-attachments/assets/ed73a084-e401-4deb-95b2-a0e470fd140f" />

Uma nova feature será criada, também para responder a mesma issue: https://github.com/Pedro-Miguel20/ninjaguerreiroteste/issues/28